### PR TITLE
Bare script envelopes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,10 @@ pub enum EmbeddingType {
     OpReturn,
     /// A taproot annex
     TaprootAnnex,
-    /// An `OP_FALSE OP_IF <DATA> OP_ENDIF` envelope
+    /// An `OP_FALSE OP_IF <DATA> OP_ENDIF` envelope in witness script
     WitnessEnvelope(ScriptType),
+    /// An `OP_FALSE OP_IF <DATA> OP_ENDIF` envelope in bare output script
+    BareEnvelope,
 }
 
 /// The location where data exists in a transaction
@@ -64,7 +66,7 @@ pub enum EmbeddingLocation {
         input: usize,
     },
 
-    /// An `OP_FALSE OP_IF <DATA> OP_ENDIF` envelope with the input index, envelope index, and data push sizes
+    /// An `OP_FALSE OP_IF <DATA> OP_ENDIF` witness envelope with the input index, envelope index, and data push sizes
     ///
     /// Witness envelopes are found in the following contexts:
     /// 1. TapScript leaf scripts in Taproot script path spends (P2TR)
@@ -79,6 +81,16 @@ pub enum EmbeddingLocation {
         /// The script type
         script_type: ScriptType,
     },
+
+    /// An `OP_FALSE OP_IF <DATA> OP_ENDIF` bare script envelope with the output index, envelope index, and data push sizes
+    BareEnvelope {
+        /// The index of the transaction output
+        output: usize,
+        /// The index of the envelope within the script
+        index: usize,
+        /// The sizes of individual data pushes within the envelope
+        pushes: Vec<usize>,
+    },
 }
 
 impl EmbeddingLocation {
@@ -86,6 +98,7 @@ impl EmbeddingLocation {
     pub fn to_type(&self) -> EmbeddingType {
         match self {
             EmbeddingLocation::OpReturn { .. } => EmbeddingType::OpReturn,
+            EmbeddingLocation::BareEnvelope { .. } => EmbeddingType::BareEnvelope,
             EmbeddingLocation::TaprootAnnex { .. } => EmbeddingType::TaprootAnnex,
             EmbeddingLocation::WitnessEnvelope { script_type, .. } => {
                 EmbeddingType::WitnessEnvelope(*script_type)
@@ -140,6 +153,7 @@ impl Embedding {
 
         let (index, sub_index) = match self.location {
             EmbeddingLocation::OpReturn { output } => (output, None),
+            EmbeddingLocation::BareEnvelope { output, index, .. } => (output, Some(index)),
             EmbeddingLocation::TaprootAnnex { input } => (input, None),
             EmbeddingLocation::WitnessEnvelope { input, index, .. } => (input, Some(index)),
         };
@@ -163,19 +177,41 @@ impl Embedding {
         let mut embeddings = Vec::new();
         let txid = tx.compute_txid();
 
-        // OP_RETURN
+        // OP_RETURN / Bare Envelope
         for (output, txout) in tx.output.iter().enumerate() {
-            if !txout.script_pubkey.is_op_return() {
-                continue;
+            if txout.script_pubkey.is_op_return() {
+                let location = EmbeddingLocation::OpReturn { output };
+
+                embeddings.push(Self {
+                    bytes: txout.script_pubkey.to_bytes()[1..].to_vec(),
+                    txid,
+                    location,
+                });
+            } else {
+                let envelopes = envelope::from_script(&txout.script_pubkey);
+
+                for (index, envelope) in envelopes.into_iter().enumerate() {
+                    let mut bytes = Vec::new();
+                    let mut pushes = Vec::new();
+
+                    for chunk in envelope {
+                        bytes.extend(chunk.clone());
+                        pushes.push(chunk.len());
+                    }
+
+                    let location = EmbeddingLocation::BareEnvelope {
+                        output,
+                        index,
+                        pushes,
+                    };
+
+                    embeddings.push(Self {
+                        bytes,
+                        txid,
+                        location,
+                    });
+                }
             }
-
-            let location = EmbeddingLocation::OpReturn { output };
-
-            embeddings.push(Self {
-                bytes: txout.script_pubkey.to_bytes()[1..].to_vec(),
-                txid,
-                location,
-            });
         }
 
         // Witness Envelope
@@ -262,8 +298,11 @@ impl fmt::Display for EmbeddingType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             EmbeddingType::OpReturn => write!(f, "OP_RETURN"),
+            EmbeddingType::BareEnvelope => write!(f, "Bare Envelope"),
             EmbeddingType::TaprootAnnex => write!(f, "Taproot Annex"),
-            EmbeddingType::WitnessEnvelope(script_type) => write!(f, "{} Envelope", script_type),
+            EmbeddingType::WitnessEnvelope(script_type) => {
+                write!(f, "{} Witness Envelope", script_type)
+            }
         }
     }
 }
@@ -273,6 +312,9 @@ impl fmt::Display for EmbeddingLocation {
         match self {
             EmbeddingLocation::OpReturn { output } => {
                 write!(f, "OP_RETURN at output {}", output)
+            }
+            EmbeddingLocation::BareEnvelope { output, index, .. } => {
+                write!(f, "Bare Envelope at output {} (index {})", output, index)
             }
             EmbeddingLocation::TaprootAnnex { input } => {
                 write!(f, "Taproot Annex at input {}", input)
@@ -285,7 +327,7 @@ impl fmt::Display for EmbeddingLocation {
             } => {
                 write!(
                     f,
-                    "{} Envelope at input {} (index {})",
+                    "{} Witness Envelope at input {} (index {})",
                     script_type, input, index
                 )
             }
@@ -320,6 +362,20 @@ impl fmt::Display for EmbeddingId {
 
                 write!(f, "{}:{}:{}", self.txid, type_code, self.index)
             }
+            EmbeddingType::BareEnvelope => {
+                let type_code = "be";
+                if let Some(sub_index) = self.sub_index {
+                    if sub_index > 0 {
+                        return write!(
+                            f,
+                            "{}:{}:{}:{}",
+                            self.txid, type_code, self.index, sub_index
+                        );
+                    }
+                }
+
+                write!(f, "{}:{}:{}", self.txid, type_code, self.index)
+            }
         }
     }
 }
@@ -338,6 +394,7 @@ impl FromStr for EmbeddingId {
 
         let embedding_type = match parts[1] {
             "rt" => EmbeddingType::OpReturn,
+            "be" => EmbeddingType::BareEnvelope,
             "ta" => EmbeddingType::TaprootAnnex,
             "le" => EmbeddingType::WitnessEnvelope(ScriptType::Legacy),
             "te" => EmbeddingType::WitnessEnvelope(ScriptType::Tapscript),
@@ -358,9 +415,14 @@ impl FromStr for EmbeddingId {
             None
         };
 
-        // sub_index should only be present in envelopes
+        // sub_index should only be present in witness and bare envelopes
         match embedding_type {
             EmbeddingType::WitnessEnvelope(_) => {
+                if sub_index.is_none() {
+                    sub_index = Some(0);
+                }
+            }
+            EmbeddingType::BareEnvelope => {
                 if sub_index.is_none() {
                     sub_index = Some(0);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,7 +487,13 @@ mod tests {
             EmbeddingType::WitnessEnvelope(ScriptType::Tapscript)
         );
 
-        for loc in [op_return_loc, bare_loc, annex_loc, legacy_loc, tapscript_loc] {
+        for loc in [
+            op_return_loc,
+            bare_loc,
+            annex_loc,
+            legacy_loc,
+            tapscript_loc,
+        ] {
             let embedding = Embedding {
                 bytes: vec![1, 2, 3],
                 txid: Txid::all_zeros(),
@@ -563,8 +569,14 @@ mod tests {
             lock_time: LockTime::ZERO,
             input: vec![],
             output: vec![
-                TxOut { value: Amount::from_sat(1000), script_pubkey: script0 },
-                TxOut { value: Amount::from_sat(2000), script_pubkey: script1 },
+                TxOut {
+                    value: Amount::from_sat(1000),
+                    script_pubkey: script0,
+                },
+                TxOut {
+                    value: Amount::from_sat(2000),
+                    script_pubkey: script1,
+                },
             ],
         };
 
@@ -574,17 +586,29 @@ mod tests {
         assert_eq!(embeddings[0].bytes, b"data1");
         assert_eq!(
             embeddings[0].location,
-            EmbeddingLocation::BareEnvelope { output: 0, index: 0, pushes: vec![5] }
+            EmbeddingLocation::BareEnvelope {
+                output: 0,
+                index: 0,
+                pushes: vec![5]
+            }
         );
         assert_eq!(embeddings[1].bytes, b"data2");
         assert_eq!(
             embeddings[1].location,
-            EmbeddingLocation::BareEnvelope { output: 0, index: 1, pushes: vec![5] }
+            EmbeddingLocation::BareEnvelope {
+                output: 0,
+                index: 1,
+                pushes: vec![5]
+            }
         );
         assert_eq!(embeddings[2].bytes, b"data3data4");
         assert_eq!(
             embeddings[2].location,
-            EmbeddingLocation::BareEnvelope { output: 1, index: 0, pushes: vec![5, 5] }
+            EmbeddingLocation::BareEnvelope {
+                output: 1,
+                index: 0,
+                pushes: vec![5, 5]
+            }
         );
     }
 
@@ -805,8 +829,10 @@ mod tests {
 
         // 5. Create bare envelope output
         let bare_builder = envelope::append_bytes_to_builder(b"bare-data", Builder::new());
-        let bare_output =
-            TxOut { value: Amount::from_sat(5000), script_pubkey: bare_builder.into_script() };
+        let bare_output = TxOut {
+            value: Amount::from_sat(5000),
+            script_pubkey: bare_builder.into_script(),
+        };
 
         // Create the transaction
         let tx = Transaction {
@@ -872,7 +898,11 @@ mod tests {
         assert_eq!(embeddings[2].bytes, b"bare-data");
         assert_eq!(
             embeddings[2].location,
-            EmbeddingLocation::BareEnvelope { output: 3, index: 0, pushes: vec![9] }
+            EmbeddingLocation::BareEnvelope {
+                output: 3,
+                index: 0,
+                pushes: vec![9]
+            }
         );
 
         assert_eq!(embeddings[3].bytes, b"p2wsh-data");
@@ -1101,7 +1131,11 @@ mod tests {
         let bare_embedding = Embedding {
             bytes: vec![1, 2, 3],
             txid,
-            location: EmbeddingLocation::BareEnvelope { output: 0, index: 1, pushes: vec![] },
+            location: EmbeddingLocation::BareEnvelope {
+                output: 0,
+                index: 1,
+                pushes: vec![],
+            },
         };
         let bare_id = bare_embedding.id();
         assert_eq!(bare_id.txid, txid);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,7 @@ impl fmt::Display for EmbeddingType {
             EmbeddingType::BareEnvelope => write!(f, "Bare Envelope"),
             EmbeddingType::TaprootAnnex => write!(f, "Taproot Annex"),
             EmbeddingType::WitnessEnvelope(script_type) => {
-                write!(f, "{} Witness Envelope", script_type)
+                write!(f, "{script_type} Witness Envelope")
             }
         }
     }
@@ -311,13 +311,13 @@ impl fmt::Display for EmbeddingLocation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             EmbeddingLocation::OpReturn { output } => {
-                write!(f, "OP_RETURN at output {}", output)
+                write!(f, "OP_RETURN at output {output}")
             }
             EmbeddingLocation::BareEnvelope { output, index, .. } => {
-                write!(f, "Bare Envelope at output {} (index {})", output, index)
+                write!(f, "Bare Envelope at output {output} (index {index})")
             }
             EmbeddingLocation::TaprootAnnex { input } => {
-                write!(f, "Taproot Annex at input {}", input)
+                write!(f, "Taproot Annex at input {input}")
             }
             EmbeddingLocation::WitnessEnvelope {
                 input,
@@ -327,8 +327,7 @@ impl fmt::Display for EmbeddingLocation {
             } => {
                 write!(
                     f,
-                    "{} Witness Envelope at input {} (index {})",
-                    script_type, input, index
+                    "{script_type} Witness Envelope at input {input} (index {index})"
                 )
             }
         }
@@ -339,10 +338,10 @@ impl fmt::Display for EmbeddingId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.embedding_type {
             EmbeddingType::OpReturn => {
-                write!(f, "{}:rt:{}", self.txid, self.index)
+                write!(f, "{}:{}:{}", self.txid, "rt", self.index)
             }
             EmbeddingType::TaprootAnnex => {
-                write!(f, "{}:ta:{}", self.txid, self.index)
+                write!(f, "{}:{}:{}", self.txid, "ta", self.index)
             }
             EmbeddingType::WitnessEnvelope(script_type) => {
                 let type_code = match script_type {
@@ -954,31 +953,31 @@ mod tests {
         let txid_str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
         // OP_RETURN
-        let op_return_id = EmbeddingId::from_str(&format!("{}:rt:2", txid_str)).unwrap();
+        let op_return_id = EmbeddingId::from_str(&format!("{txid_str}:rt:2")).unwrap();
         assert_eq!(op_return_id.embedding_type, EmbeddingType::OpReturn);
         assert_eq!(op_return_id.index, 2);
         assert_eq!(op_return_id.sub_index, None);
 
         // Bare envelope with explicit sub_index
-        let bare_id = EmbeddingId::from_str(&format!("{}:be:0:3", txid_str)).unwrap();
+        let bare_id = EmbeddingId::from_str(&format!("{txid_str}:be:0:3")).unwrap();
         assert_eq!(bare_id.embedding_type, EmbeddingType::BareEnvelope);
         assert_eq!(bare_id.index, 0);
         assert_eq!(bare_id.sub_index, Some(3));
 
         // Bare envelope without sub_index (defaults to 0)
-        let bare_id2 = EmbeddingId::from_str(&format!("{}:be:0", txid_str)).unwrap();
+        let bare_id2 = EmbeddingId::from_str(&format!("{txid_str}:be:0")).unwrap();
         assert_eq!(bare_id2.embedding_type, EmbeddingType::BareEnvelope);
         assert_eq!(bare_id2.index, 0);
         assert_eq!(bare_id2.sub_index, Some(0));
 
         // TaprootAnnex
-        let annex_id = EmbeddingId::from_str(&format!("{}:ta:1", txid_str)).unwrap();
+        let annex_id = EmbeddingId::from_str(&format!("{txid_str}:ta:1")).unwrap();
         assert_eq!(annex_id.embedding_type, EmbeddingType::TaprootAnnex);
         assert_eq!(annex_id.index, 1);
         assert_eq!(annex_id.sub_index, None);
 
         // Legacy envelope with explicit sub_index
-        let legacy_id = EmbeddingId::from_str(&format!("{}:le:0:3", txid_str)).unwrap();
+        let legacy_id = EmbeddingId::from_str(&format!("{txid_str}:le:0:3")).unwrap();
         assert_eq!(
             legacy_id.embedding_type,
             EmbeddingType::WitnessEnvelope(ScriptType::Legacy)
@@ -987,7 +986,7 @@ mod tests {
         assert_eq!(legacy_id.sub_index, Some(3));
 
         // Legacy envelope without sub_index (defaults to 0)
-        let legacy_id2 = EmbeddingId::from_str(&format!("{}:le:0", txid_str)).unwrap();
+        let legacy_id2 = EmbeddingId::from_str(&format!("{txid_str}:le:0")).unwrap();
         assert_eq!(
             legacy_id2.embedding_type,
             EmbeddingType::WitnessEnvelope(ScriptType::Legacy)
@@ -996,7 +995,7 @@ mod tests {
         assert_eq!(legacy_id2.sub_index, Some(0));
 
         // Tapscript envelope with explicit sub_index
-        let tapscript_id = EmbeddingId::from_str(&format!("{}:te:2:1", txid_str)).unwrap();
+        let tapscript_id = EmbeddingId::from_str(&format!("{txid_str}:te:2:1")).unwrap();
         assert_eq!(
             tapscript_id.embedding_type,
             EmbeddingType::WitnessEnvelope(ScriptType::Tapscript)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,10 +338,10 @@ impl fmt::Display for EmbeddingId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.embedding_type {
             EmbeddingType::OpReturn => {
-                write!(f, "{}:{}:{}", self.txid, "rt", self.index)
+                write!(f, "{}:rt:{}", self.txid, self.index)
             }
             EmbeddingType::TaprootAnnex => {
-                write!(f, "{}:{}:{}", self.txid, "ta", self.index)
+                write!(f, "{}:ta:{}", self.txid, self.index)
             }
             EmbeddingType::WitnessEnvelope(script_type) => {
                 let type_code = match script_type {
@@ -1064,12 +1064,12 @@ mod tests {
 
         let txid_str = txid.to_string();
 
-        assert_eq!(op_return_id.to_string(), format!("{}:rt:2", txid_str));
-        assert_eq!(bare_id.to_string(), format!("{}:be:0:3", txid_str));
-        assert_eq!(bare_id2.to_string(), format!("{}:be:2", txid_str));
-        assert_eq!(annex_id.to_string(), format!("{}:ta:1", txid_str));
-        assert_eq!(legacy_id.to_string(), format!("{}:le:0:3", txid_str));
-        assert_eq!(tapscript_id.to_string(), format!("{}:te:2", txid_str));
+        assert_eq!(op_return_id.to_string(), format!("{txid_str}:rt:2"));
+        assert_eq!(bare_id.to_string(), format!("{txid_str}:be:0:3"));
+        assert_eq!(bare_id2.to_string(), format!("{txid_str}:be:2"));
+        assert_eq!(annex_id.to_string(), format!("{txid_str}:ta:1"));
+        assert_eq!(legacy_id.to_string(), format!("{txid_str}:le:0:3"));
+        assert_eq!(tapscript_id.to_string(), format!("{txid_str}:te:2"));
     }
 
     #[test]
@@ -1081,7 +1081,7 @@ mod tests {
         assert_eq!(err, EmbeddingIdError::InvalidFormat);
 
         // Too many parts
-        let err = EmbeddingId::from_str(&format!("{}:rt:2:3:extra", txid_str)).unwrap_err();
+        let err = EmbeddingId::from_str(&format!("{txid_str}:rt:2:3:extra")).unwrap_err();
         assert_eq!(err, EmbeddingIdError::InvalidFormat);
 
         // Invalid txid
@@ -1089,23 +1089,23 @@ mod tests {
         assert_eq!(err, EmbeddingIdError::InvalidTxid);
 
         // Invalid type
-        let err = EmbeddingId::from_str(&format!("{}:invalid:2", txid_str)).unwrap_err();
+        let err = EmbeddingId::from_str(&format!("{txid_str}:invalid:2")).unwrap_err();
         assert_eq!(err, EmbeddingIdError::InvalidType);
 
         // Invalid index (not a number)
-        let err = EmbeddingId::from_str(&format!("{}:rt:abc", txid_str)).unwrap_err();
+        let err = EmbeddingId::from_str(&format!("{txid_str}:rt:abc")).unwrap_err();
         assert_eq!(err, EmbeddingIdError::InvalidIndex);
 
         // Invalid sub_index (not a number)
-        let err = EmbeddingId::from_str(&format!("{}:te:2:abc", txid_str)).unwrap_err();
+        let err = EmbeddingId::from_str(&format!("{txid_str}:te:2:abc")).unwrap_err();
         assert_eq!(err, EmbeddingIdError::InvalidIndex);
 
         // Sub_index not allowed for OP_RETURN
-        let err = EmbeddingId::from_str(&format!("{}:rt:2:1", txid_str)).unwrap_err();
+        let err = EmbeddingId::from_str(&format!("{txid_str}:rt:2:1")).unwrap_err();
         assert_eq!(err, EmbeddingIdError::InvalidFormat);
 
         // Sub_index not allowed for TaprootAnnex
-        let err = EmbeddingId::from_str(&format!("{}:ta:1:2", txid_str)).unwrap_err();
+        let err = EmbeddingId::from_str(&format!("{txid_str}:ta:1:2")).unwrap_err();
         assert_eq!(err, EmbeddingIdError::InvalidFormat);
     }
 


### PR DESCRIPTION
Adds support for envelopes in outputs with a bare `scriptPubKey`.

While non-standard, this output type may be useful for token-for-token PSBT swaps. The offerree can sign a single output with `SINGLE|ANYONECANPAY`, committing to their public key and the conditional offer data. A taker could then claim the offered amount by sending the requisite number of tokens to this output.

If `CTV` is adopted, this type of offer would become more ergonomic, because the offerree can pre-commit to a subsequent transaction spending the bare output to a modern output type, without needing to manage a legacy wallet.